### PR TITLE
:zap: Perf: Remove comments from lib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "semantic-release": "semantic-release -e ./config/release.config.js",
-    "compile": "babel -d lib/ src/ --source-maps both",
+    "compile": "babel -d lib/ src/ --source-maps both --no-comments",
     "prepare": "npm run compile",
     "test": "nyc ava",
     "coverage": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
What's new ?

- Remove all the comments (Jsdoc, etc.) of the **lib** version.

Since babel provides sourcemaps and jsdoc has this config : 
```js
"source": {
    "include": [ "./src" ]
  }
```
It is not useful to keep these comments :) 